### PR TITLE
Lightswitch problem solved with bitwise operators

### DIFF
--- a/light_switches/solution_jfleck.rb
+++ b/light_switches/solution_jfleck.rb
@@ -1,7 +1,7 @@
 #!/usr/bin/env ruby
 
-def range(s, e)
-  ((2**((e-s)+1) - 1) << s)
+def bitmap(startpoint, endpoint)
+  ((2**((endpoint-startpoint)+1) - 1) << startpoint)
 end
 
 size = nil
@@ -9,11 +9,11 @@ switches = 0b0
 print 'Please enter the number of switches> '
 while line=gets
   if size
-    points = line.split.sort.map(&:to_i)
-    s = points[0]
-    e = points[1]
-    range = range(s, e)
-    puts "current state is #{switches.to_s(2)}, range is #{points} or #{range.to_s(2)}, new state is #{(switches = switches ^ range).to_s(2)}, there are #{switches.to_s(2).count('1')} lights on"
+    points     = line.split.sort.map(&:to_i)
+    startpoint = points[0]
+    endpoint   = points[1]
+    bitmap     = bitmap(startpoint, endpoint)
+    puts "current state is #{switches.to_s(2)}, range is #{points} or #{bitmap.to_s(2)}, new state is #{(switches = switches ^ bitmap).to_s(2)}, there are #{switches.to_s(2).count('1')} lights on"
   else
     size = line.to_i
     puts "Size is #{size}"

--- a/light_switches/solution_jfleck.rb
+++ b/light_switches/solution_jfleck.rb
@@ -1,0 +1,22 @@
+#!/usr/bin/env ruby
+
+def range(s, e)
+  ((2**((e-s)+1) - 1) << s)
+end
+
+size = nil
+switches = 0b0
+print 'Please enter the number of switches> '
+while line=gets
+  if size
+    points = line.split.sort.map(&:to_i)
+    s = points[0]
+    e = points[1]
+    range = range(s, e)
+    puts "current state is #{switches.to_s(2)}, range is #{points} or #{range.to_s(2)}, new state is #{(switches = switches ^ range).to_s(2)}, there are #{switches.to_s(2).count('1')} lights on"
+  else
+    size = line.to_i
+    puts "Size is #{size}"
+  end
+  print 'Flick a range of switches from X to Y> '
+end


### PR DESCRIPTION
The idea is that you represent the switches as an array of bits (0 for `off`, 1 for `on`).
In order to flip a range of switches, you represent that range as a bitmask and apply the mask to the switches bit array using an exclusive or operation.

Run with: `./light_switches/solution_jfleck.rb`

Output looks like this:

```
Please enter the number of switches> 10
Size is 10
Flick a range of switches from X to Y> 3 6
current state is 0, range is [3, 6] or 1111000, new state is 1111000, there are 4 lights on
Flick a range of switches from X to Y> 0 4
current state is 1111000, range is [0, 4] or 11111, new state is 1100111, there are 5 lights on
Flick a range of switches from X to Y> 7 3
current state is 1100111, range is [3, 7] or 11111000, new state is 10011111, there are 6 lights on
Flick a range of switches from X to Y> 9 9
current state is 10011111, range is [9, 9] or 1000000000, new state is 1010011111, there are 7 lights on
Flick a range of switches from X to Y> 
```

For funzies, this can also be accomplished as a one-liner via the command line like this, where `input` is the name of a file containing pairs of integers representing the ranges (you don't actually need to know the total number of switches):

```
cat input | ruby -na -e 'BEGIN{ switches = 0b0 }; $F.sort!.map!(&:to_i); switches ^= ((2**(($F[1]-$F[0])+1) - 1) << $F[0]); END{ print switches.to_s(2).count("1") }'
```